### PR TITLE
EM-2627 Harden material import

### DIFF
--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -1,3 +1,4 @@
+#define  __STDC_LIMIT_MACROS        // Required to get UINTxx_MAX macros to work in stdint.h (included from avr/pgmspace.h)
 #include <avr/pgmspace.h>
 
 #include "Configuration.h"
@@ -49,13 +50,15 @@ static void lcd_menu_material_temperature_settings();
 static void lcd_menu_material_retraction_settings();
 static void lcd_menu_material_retraction_settings_per_nozzle();
 static void lcd_menu_material_settings_store();
-static bool lcd_material_check_temperature(unsigned long temperature);
-static bool lcd_material_check_bed_temperature(unsigned long temperature);
-static bool lcd_material_check_fan_speed(unsigned long fanspeed);
-static bool lcd_material_check_material_flow(unsigned long flow);
-static bool lcd_material_check_material_diameter(double diameter);
-static bool lcd_material_check_retraction_length(float length);
-static bool lcd_material_check_retraction_speed(unsigned long speed);
+static bool hasInvalidNozzleTemperature(uint16_t temperature);
+static bool hasInvalidBedTemperature(uint16_t temperature);
+static bool hasInvalidFanSpeed(uint8_t fanspeed);
+static bool hasInvalidMaterialFlow(uint16_t flow);
+static bool hasInvalidDiameter(float diameter);
+static bool hasInvalidRetractionLength(uint16_t length);
+static bool hasInvalidRetractionSpeed(uint16_t speed);
+static uint8_t strToUint8(char* str);
+static uint16_t strToUint16(char* str, uint8_t scaling_factor=1);
 
 static void cancelMaterialInsert()
 {
@@ -535,6 +538,24 @@ static void lcd_menu_material_import_done()
     lcd_lib_update_screen();
 }
 
+static uint8_t strToUint8(char* str)
+{
+    return min(strToUint16(str), UINT8_MAX);
+}
+
+// Extracts a value from the given string and applies a scaling factor before converting the result to an uint16_t.
+// Advantage of using this function is that it handles underflows and overflows in a controlled manner by limiting the
+// returned values to what is allowed in a uint16, i.e. it returns a 0 or UINT16_MAX.
+// @param str is a C-string beginning with the representation of a floating-point number.
+// @param scaling_factor is an optional scaling factor to allow for more precision when storing the data in EEPROM as a scaled integer.
+// @return the converted value as an uint16. On underflow limited to a 0, or on overflow limited to UINT16_MAX.
+static uint16_t strToUint16(char* str, uint8_t scaling_factor)
+{
+    double value = strtod(str, NULL);
+    value *= scaling_factor;
+    return max(0, min(value, UINT16_MAX));
+}
+
 static void lcd_menu_material_import()
 {
     if (!card.sdInserted)
@@ -573,7 +594,7 @@ static void lcd_menu_material_import()
     material_load_successful = true;  // Set to false during error handling
 
     char buffer[32];
-    uint8_t count = 0xFF;
+    uint8_t count = uint8_t(-1);
     while(card.fgets(buffer, sizeof(buffer)) > 0)
     {
         buffer[sizeof(buffer)-1] = '\0';
@@ -597,51 +618,51 @@ static void lcd_menu_material_import()
                     SERIAL_ECHOLN(c);
                 }else if (strcmp_P(buffer, PSTR("temperature")) == 0)
                 {
-                    long temperature = strtol(c, NULL, 10);
-                    if(lcd_material_check_temperature(temperature)) {
+                    uint16_t temperature = strToUint16(c);
+                    if (hasInvalidNozzleTemperature(temperature)) {
                         temperature = 210;  // Default copied from PLA
                         SERIAL_ERROR_START;
-                        SERIAL_ERRORLNPGM("lcd_material_check_temperature found problem");
+                        SERIAL_ERRORLNPGM("hasInvalidNozzleTemperature found problem");
                         material_load_successful = false;
                     }
                     eeprom_write_word(EEPROM_MATERIAL_TEMPERATURE_OFFSET(count), temperature);
                 }else if (strcmp_P(buffer, PSTR("bed_temperature")) == 0) {
-                    long bed_temperature = strtol(c, NULL, 10);
-                    if (lcd_material_check_bed_temperature(bed_temperature))
+                    uint16_t bed_temperature = strToUint16(c);
+                    if (hasInvalidBedTemperature(bed_temperature))
                     {
                         bed_temperature = 60;  // Default copied from PLA
                         SERIAL_ERROR_START;
-                        SERIAL_ERRORLNPGM("lcd_material_check_bed_temperature found problem");
+                        SERIAL_ERRORLNPGM("hasInvalidBedTemperature found problem");
                         material_load_successful = false;
                     }
                     eeprom_write_word(EEPROM_MATERIAL_BED_TEMPERATURE_OFFSET(count), bed_temperature);
                 }else if (strcmp_P(buffer, PSTR("fan_speed")) == 0)
                 {
-                    long fan_speed = strtol(c, NULL, 10);
-                    if(lcd_material_check_fan_speed(fan_speed)) {
+                    uint8_t fan_speed = strToUint8(c);
+                    if (hasInvalidFanSpeed(fan_speed)) {
                         fan_speed = 100; // Default copied from PLA
                         SERIAL_ERROR_START;
-                        SERIAL_ERRORLNPGM("lcd_material_check_fan_speed found problem");
+                        SERIAL_ERRORLNPGM("hasInvalidFanSpeed found problem");
                         material_load_successful = false;
                     }
                     eeprom_write_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(count), fan_speed);
                 }else if (strcmp_P(buffer, PSTR("flow")) == 0)
                 {
-                    long flow = strtol(c, NULL, 10);
-                    if(lcd_material_check_material_flow(flow)) {
+                    uint16_t flow = strToUint16(c);
+                    if (hasInvalidMaterialFlow(flow)) {
                         flow = 100; // Default copied from PLA
                         SERIAL_ERROR_START;
-                        SERIAL_ERRORLNPGM("lcd_material_check_material_flow found problem");
+                        SERIAL_ERRORLNPGM("hasInvalidMaterialFlow found problem");
                         material_load_successful = false;
                     }
                     eeprom_write_word(EEPROM_MATERIAL_FLOW_OFFSET(count), flow);
                 }else if (strcmp_P(buffer, PSTR("diameter")) == 0)
                 {
                     double diameter = strtod(c, NULL);
-                    if(lcd_material_check_material_diameter(diameter)) {
+                    if (hasInvalidDiameter(diameter)) {
                         diameter = 2.85; // Default copied from PLA
                         SERIAL_ERROR_START;
-                        SERIAL_ERRORLNPGM("lcd_material_check_material_diameter found problem");
+                        SERIAL_ERRORLNPGM("hasInvalidDiameter found problem");
                         material_load_successful = false;
                     }
                     eeprom_write_float(EEPROM_MATERIAL_DIAMETER_OFFSET(count), diameter);
@@ -662,11 +683,11 @@ static void lcd_menu_material_import()
                     float_to_string(nozzleIndexToNozzleSize(nozzle), ptr);
                     if (strcmp(buffer, buffer2) == 0)
                     {
-                        long extra_temperature = strtol(c, NULL, 10);
-                        if(lcd_material_check_temperature(extra_temperature)) {
+                        uint16_t extra_temperature = strToUint16(c);
+                        if (hasInvalidNozzleTemperature(extra_temperature)) {
                             extra_temperature = 210; // Default copied from PLA
                             SERIAL_ERROR_START;
-                            SERIAL_ERRORLNPGM("lcd_material_check_temperature found problem");
+                            SERIAL_ERRORLNPGM("hasInvalidNozzleTemperature found problem");
                             material_load_successful = false;
                         }
                         eeprom_write_word(EEPROM_MATERIAL_EXTRA_TEMPERATURE_OFFSET(count, nozzle), extra_temperature);
@@ -677,11 +698,11 @@ static void lcd_menu_material_import()
                     ptr = float_to_string(nozzleIndexToNozzleSize(nozzle), ptr);
                     if (strcmp(buffer, buffer2) == 0)
                     {
-                        float retraction_length = atof(c) * EEPROM_RETRACTION_LENGTH_SCALE;
-                        if(lcd_material_check_retraction_length(retraction_length)) {
-                            retraction_length = 6.5f; // Default copied from PLA
+                        uint16_t retraction_length = strToUint16(c, EEPROM_RETRACTION_LENGTH_SCALE);
+                        if (hasInvalidRetractionLength(retraction_length)) {
+                            retraction_length = 6.5 * EEPROM_RETRACTION_LENGTH_SCALE;   // Default copied from PLA
                             SERIAL_ERROR_START;
-                            SERIAL_ERRORLNPGM("lcd_material_check_retraction_length found problem");
+                            SERIAL_ERRORLNPGM("hasInvalidRetractionLength found problem");
                             material_load_successful = false;
                         }
                         eeprom_write_word(EEPROM_MATERIAL_EXTRA_RETRACTION_LENGTH_OFFSET(count, nozzle), retraction_length);
@@ -692,11 +713,11 @@ static void lcd_menu_material_import()
                     ptr = float_to_string(nozzleIndexToNozzleSize(nozzle), ptr);
                     if (strcmp(buffer, buffer2) == 0)
                     {
-                        float retraction_speed = atof(c) * EEPROM_RETRACTION_SPEED_SCALE;
-                        if(lcd_material_check_retraction_speed(retraction_speed)) {
-                            retraction_speed = 25.0f; // Default copied from PLA
+                        uint16_t retraction_speed = strToUint16(c, EEPROM_RETRACTION_SPEED_SCALE);
+                        if (hasInvalidRetractionSpeed(retraction_speed)) {
+                            retraction_speed = 25 * EEPROM_RETRACTION_SPEED_SCALE;  // Default copied from PLA
                             SERIAL_ERROR_START;
-                            SERIAL_ERRORLNPGM("lcd_material_check_retraction_speed found problem");
+                            SERIAL_ERRORLNPGM("hasInvalidRetractionSpeed found problem");
                             material_load_successful = false;
                         }
                         eeprom_write_byte(EEPROM_MATERIAL_EXTRA_RETRACTION_SPEED_OFFSET(count, nozzle), retraction_speed);
@@ -1488,41 +1509,41 @@ void lcd_material_store_current_material()
     }
 }
 
-static bool lcd_material_check_temperature(unsigned long temperature)
+static bool hasInvalidNozzleTemperature(uint16_t temperature)
 {
     return temperature == 0 || temperature > HEATER_0_MAXTEMP;
 }
 
-static bool lcd_material_check_bed_temperature(unsigned long temperature)
+static bool hasInvalidBedTemperature(uint16_t temperature)
 {
     return temperature > BED_MAXTEMP;
 }
 
-static bool lcd_material_check_fan_speed(unsigned long fanspeed)
+static bool hasInvalidFanSpeed(uint8_t fanspeed)
 {
     return fanspeed > 100;
 }
 
-static bool lcd_material_check_material_flow(unsigned long flow)
+static bool hasInvalidMaterialFlow(uint16_t flow)
 {
-    return flow > 1000;
+    return flow == 0 || flow > 1000;
 }
 
-static bool lcd_material_check_material_diameter(double diameter)
+static bool hasInvalidDiameter(float diameter)
 {
     return diameter < 0.1 || diameter > 10.0;
 }
 
-static bool lcd_material_check_retraction_length(float length)
+static bool hasInvalidRetractionLength(uint16_t length)
 {
     //More than 20mm retraction is not a valid value
     return length > (20 * EEPROM_RETRACTION_LENGTH_SCALE);
 }
 
-static bool lcd_material_check_retraction_speed(unsigned long speed)
+static bool hasInvalidRetractionSpeed(uint16_t speed)
 {
     //More than 45mm/s is not a valid value
-    return speed ==0 || speed > (45 * EEPROM_RETRACTION_SPEED_SCALE);
+    return speed == 0 || speed > (45 * EEPROM_RETRACTION_SPEED_SCALE);
 }
 
 bool lcd_material_verify_material_settings()
@@ -1533,31 +1554,30 @@ bool lcd_material_verify_material_settings()
     while(cnt > 0)
     {
         cnt --;
-        if (lcd_material_check_temperature(eeprom_read_word(EEPROM_MATERIAL_TEMPERATURE_OFFSET(cnt))))
+        if (hasInvalidNozzleTemperature(eeprom_read_word(EEPROM_MATERIAL_TEMPERATURE_OFFSET(cnt))))
             return false;
 #if TEMP_SENSOR_BED != 0
-        if (lcd_material_check_bed_temperature(eeprom_read_word(EEPROM_MATERIAL_BED_TEMPERATURE_OFFSET(cnt))))
+        if (hasInvalidBedTemperature(eeprom_read_word(EEPROM_MATERIAL_BED_TEMPERATURE_OFFSET(cnt))))
             return false;
 #endif
-        if (lcd_material_check_fan_speed(eeprom_read_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(cnt))))
+        if (hasInvalidFanSpeed(eeprom_read_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(cnt))))
             return false;
-        if (lcd_material_check_material_flow(eeprom_read_word(EEPROM_MATERIAL_FLOW_OFFSET(cnt))))
+        if (hasInvalidMaterialFlow(eeprom_read_word(EEPROM_MATERIAL_FLOW_OFFSET(cnt))))
             return false;
-        if (lcd_material_check_material_diameter(eeprom_read_float(EEPROM_MATERIAL_DIAMETER_OFFSET(cnt))))
+        if (hasInvalidDiameter(eeprom_read_float(EEPROM_MATERIAL_DIAMETER_OFFSET(cnt))))
             return false;
 
         for(uint8_t n=0; n<MATERIAL_NOZZLE_COUNT; n++)
         {
-            if (lcd_material_check_temperature(eeprom_read_word(EEPROM_MATERIAL_EXTRA_TEMPERATURE_OFFSET(cnt, n))))
+            if (hasInvalidNozzleTemperature(eeprom_read_word(EEPROM_MATERIAL_EXTRA_TEMPERATURE_OFFSET(cnt, n))))
                 return false;
-
-            if (lcd_material_check_retraction_length(eeprom_read_word(EEPROM_MATERIAL_EXTRA_RETRACTION_LENGTH_OFFSET(cnt, n))))
+            if (hasInvalidRetractionLength(eeprom_read_word(EEPROM_MATERIAL_EXTRA_RETRACTION_LENGTH_OFFSET(cnt, n))))
                 return false;
-            if (lcd_material_check_retraction_speed(eeprom_read_byte(EEPROM_MATERIAL_EXTRA_RETRACTION_SPEED_OFFSET(cnt, n))))
+            if (hasInvalidRetractionSpeed(eeprom_read_byte(EEPROM_MATERIAL_EXTRA_RETRACTION_SPEED_OFFSET(cnt, n))))
                 return false;
         }
 
-        if (lcd_material_check_temperature(eeprom_read_word(EEPROM_MATERIAL_CHANGE_TEMPERATURE(cnt))))
+        if (hasInvalidNozzleTemperature(eeprom_read_word(EEPROM_MATERIAL_CHANGE_TEMPERATURE(cnt))))
         {
             //Invalid temperature for change temperature.
             if (strcmp_P(card.longFilename, PSTR("PLA")) == 0)


### PR DESCRIPTION
- Fix the material retraction-length and -speed defaults in case of wrong values detected.
- Improve error handling for very large positive or negative numbers.
- Rename functions to be more clear and according to programming standard.
- Reduce memory usage a bit.

EM-2627