### PR TITLE
Add git tags to build releases

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -9,6 +9,11 @@
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
+
+#ifdef STRING_GIT_VERSION
+#define STRING_CONFIG_H_AUTHOR STRING_GIT_VERSION
+#endif
+
 #ifndef STRING_CONFIG_H_AUTHOR
 #define STRING_CONFIG_H_AUTHOR "Version DEV" // Who made the changes.
 #endif

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -54,6 +54,21 @@ UPLOAD_PORT        ?= /dev/arduino
 #Directory used to build files in, contains all the build files, from object files to the final hex file.
 BUILD_DIR          ?= applet
 
+# Use git-revisions for builds
+# Release version
+GIT_VERSION=$(shell git describe --tags --exact-match --dirty 2> /dev/null)
+ifeq ($(strip $(GIT_VERSION)), )
+# Dev version
+GIT_VERSION=$(shell git describe --tags --dirty 2> /dev/null)
+endif
+# Fallback if the above for some reason fail
+ifeq ($(strip $(GIT_VERSION)), )
+GIT_VERSION=$(shell git describe --always 2> /dev/null)
+endif
+ifneq ($(strip $(GIT_VERSION)), )
+GITVER='-D STRING_GIT_VERSION="$(GIT_VERSION)"'
+endif
+
 ############################################################################
 # Below here nothing should be changed...
 
@@ -284,8 +299,8 @@ CTUNING += -DMOTHERBOARD=${HARDWARE_MOTHERBOARD}
 endif
 #CEXTRA = -Wa,-adhlns=$(<:.c=.lst)
 
-CFLAGS := $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CEXTRA) $(CTUNING)
-CXXFLAGS :=         $(CDEFS) $(CINCS) -O$(OPT) -Wall    $(CEXTRA) $(CTUNING)
+CFLAGS := $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CEXTRA) $(CTUNING) $(GITVER)
+CXXFLAGS :=         $(CDEFS) $(CINCS) -O$(OPT) -Wall    $(CEXTRA) $(CTUNING) $(GITVER)
 #ASFLAGS = -Wa,-adhlns=$(<:.S=.lst),-gstabs
 LDFLAGS = -lm
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -449,6 +449,10 @@ void setup()
       SERIAL_ECHOLNPGM(STRING_CONFIG_H_AUTHOR);
       SERIAL_ECHOPGM("Compiled: ");
       SERIAL_ECHOLNPGM(__DATE__);
+      #ifdef STRING_GIT_VERSION
+        SERIAL_ECHOPGM("Git version: ");
+        SERIAL_ECHOLNPGM(STRING_GIT_VERSION);
+      #endif
     #endif
   #endif
   SERIAL_ECHO_START;


### PR DESCRIPTION
This patch adds a new string to the boot-up message "Git version: xxx"
indicating the git revision number, if the Makefile was able to run 'git
describe'. First we see if we are on a tagged release, and use just the
version tag as version. If we're not an tagged release, we try to get
the exact hash. In case this fails, we try a fallback to get anything
from git describe.

If git describe is not available or the Makefile has trouble executing
it, we do not store the version at all.

Ideally we would overwrite the real version string, Marlin 1.0.0, but it
has to be investigated if that is worth it, as some 3rd parties may
relentlessly assume this string to identify Marlin.

Note, that 'unclean/dirty' builds are postfixed with the -dirty flag,
while this will never be seen in production, it is quite possible during
development. On the OLED display will wrap the 'irty' bit onto an
invisible line.

Note, that this was once part of JediMarlin commit 625f192
("Add git tags to build releases") but was unnecessarily removed in
commit 1a6a90e ("Start with supercleaning action, delete all unused code.")

Signed-off-by: Olliver Schinagl <o.schinagl@ultimaker.com>